### PR TITLE
Add runtime dependencies and startup helper script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+aiohttp==3.9.5
 python-telegram-bot==20.3
 pymongo==4.6.1

--- a/run_bot.py
+++ b/run_bot.py
@@ -1,0 +1,17 @@
+"""Утилита для запуска MerchantBot из командной строки."""
+
+import logging
+
+from MerchantBot import main as run_merchant_bot
+
+
+def main() -> None:
+    """Точка входа для запуска Telegram-бота."""
+    try:
+        run_merchant_bot()
+    except KeyboardInterrupt:
+        logging.getLogger(__name__).info("Остановка по запросу пользователя")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add aiohttp to the runtime requirements list so the async HTTP clients run out of the box
- provide a small run_bot.py wrapper that exposes a simple CLI entry point for launching the bot

## Testing
- python -m compileall MerchantBot.py run_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68e01e1bef888326933205ab75a1fae2